### PR TITLE
add Dockerfile to support OpenROAD unified build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.dockerignore
+Dockerfile
+
+# from .gitignore 
+build
+FRlefdef
+FlexRoute*
+flexroute*
+TritonRoute*
+*.dat
+*.log
+*.param
+support/ispd18/*
+.gdb_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM centos:centos6 AS builder
+
+# install gcc 6
+RUN yum -y install centos-release-scl && \
+    yum -y install devtoolset-6 devtoolset-6-libatomic-devel
+ENV CC=/opt/rh/devtoolset-6/root/usr/bin/gcc \
+    CPP=/opt/rh/devtoolset-6/root/usr/bin/cpp \
+    CXX=/opt/rh/devtoolset-6/root/usr/bin/g++ \
+    PATH=/opt/rh/devtoolset-6/root/usr/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib:/opt/rh/devtoolset-6/root/usr/lib64/dyninst:/opt/rh/devtoolset-6/root/usr/lib/dyninst:/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib:$LD_LIBRARY_PATH
+
+# Common development tools and libraries (kitchen sink approach)
+RUN yum groupinstall -y "Development Tools" "Development Libraries"
+
+RUN yum install -y wget rh-mongodb32-boost-devel rh-mongodb32-boost-static
+ENV PATH=/opt/rh/rh-mongodb32/root/usr/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/rh/rh-mongodb32/root/usr/lib64:/opt/rh/rh-mongodb32/root/usr/lib:/opt/rh/rh-mongodb32/root/usr/lib64/dyninst:/opt/rh/rh-mongodb32/root/usr/lib/dyninst:/opt/rh/rh-mongodb32/root/usr/lib64:/opt/rh/rh-mongodb32/root/usr/lib:$LD_LIBRARY_PATH \
+    C_INCLUDE_PATH=/opt/rh/rh-mongodb32/root/usr/include \
+    CPLUS_INCLUDE_PATH=/opt/rh/rh-mongodb32/root/usr/include
+
+
+RUN wget https://cmake.org/files/v3.9/cmake-3.9.0-Linux-x86_64.sh && \
+    chmod +x cmake-3.9.0-Linux-x86_64.sh  && \
+    ./cmake-3.9.0-Linux-x86_64.sh --skip-license --prefix=/usr/local
+
+
+RUN yum install -y zlib-devel libpng-devel epel-release qt5-qtbase-devel
+
+COPY . /FastRoute4-lefdef
+RUN mkdir /FastRoute4-lefdef/build
+WORKDIR /FastRoute4-lefdef/build
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DBOOST_ROOT=/opt/rh/rh-mongodb32/root/usr ..  && \
+    make
+
+# runtime environment
+FROM centos:centos6 AS runner
+RUN yum update -y && yum install -y tcl-devel libgomp
+COPY --from=builder /FastRoute4-lefdef/build/third_party/rsyn/bin/rsyn /build/FRlefdef
+RUN useradd -ms /bin/bash openroad
+USER openroad
+WORKDIR /home/openroad


### PR DESCRIPTION
This pull request adds a Dockerfile to the repository to integrate in the unified build environment. The image is based on centos6, which is the agreed build environment for OpenROAD.

To build:
`docker build -t <image_name> .`

Binaries are in `/build` directory, which can also be run from within the container.